### PR TITLE
execute client side events async

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -6,6 +6,7 @@ var http = require('http');
 * Mock response object for receiving content without a server.
 **/
 var MockResponse = function(callback) {
+
     if (!(this instanceof MockResponse)) {
         return new MockResponse(callback);
     }
@@ -15,9 +16,11 @@ var MockResponse = function(callback) {
     this.buffer = [];
     this.statusCode = null;
     this._headers = {};
+    
     this.on('data', function(chunk) {
         this.buffer.push(chunk);
     });
+    
     this.on('pipe', function(src) {
         var buffer = this.buffer;
 
@@ -25,16 +28,19 @@ var MockResponse = function(callback) {
             buffer.push(chunk);
         })
     });
+    
     this.on('close', function() {});
 
     if (callback) {
         var self = this;
+
         var cleanup = function () {
             self.removeListener('error', cleanup)
             self.removeListener('response', cleanup)
 
             callback.apply(this, arguments)
         }
+
         this.once('error', cleanup);
         this.once('response', cleanup);
     }
@@ -45,6 +51,7 @@ util.inherits(MockResponse, events.EventEmitter);
 MockResponse.prototype.write = function(str) {
     this.buffer.push(str);
 };
+
 MockResponse.prototype.writeHead = function(statusCode, headers) {
     var that = this;
 
@@ -53,6 +60,7 @@ MockResponse.prototype.writeHead = function(statusCode, headers) {
         that.setHeader(k, headers[k]);
     });
 };
+
 MockResponse.prototype.setHeader = function(name, value, clobber) {
   if (http.ServerResponse) {
     var ret = http.ServerResponse.prototype.setHeader.call(this, name, value, clobber);
@@ -66,6 +74,7 @@ MockResponse.prototype.setHeader = function(name, value, clobber) {
     this.headers[name] += ',' + value;
   }
 };
+
 MockResponse.prototype.getHeader = function(name) {
   if (http.ServerResponse) {
     return http.ServerResponse.prototype.getHeader.call(this, name);
@@ -74,19 +83,29 @@ MockResponse.prototype.getHeader = function(name) {
     return this.headers[name];
   }
 };
+
 MockResponse.prototype.end = function(str) {
+    var self = this;
+
     this.buffer.push(str);
+    //this event is for the server
     this.emit('close');
-    this.emit('finish');
-    this.emit('end', null, { // deprecate me
-        statusCode: this.statusCode,
-        body: this.buffer.join(''),
-        headers: this._headers
-    });
-    this.emit('response', null, {
-        statusCode: this.statusCode,
-        body: this.buffer.join(''),
-        headers: this._headers
+
+    //these events are for the client, and need to execute asynchronously
+    setImmediate(function(){
+        self.emit('finish');
+        
+        self.emit('end', null, { // deprecate me
+            statusCode: self.statusCode,
+            body: self.buffer.join(''),
+            headers: self._headers
+        });
+
+        self.emit('response', null, {
+            statusCode: self.statusCode,
+            body: self.buffer.join(''),
+            headers: self._headers
+        });
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js mock / polyfill http object library for http req / res",
   "main": "index.js",
   "scripts": {
-    "test": "node ./tests/*"
+    "test": "tape tests/*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hammock",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Node.js mock / polyfill http object library for http req / res",
   "main": "index.js",
   "scripts": {

--- a/tests/post.js
+++ b/tests/post.js
@@ -27,7 +27,8 @@ test('Create  post request', function(t) {
   t.equal(bar, 'baz', 'Cookie (bar) should return the original value.');
 
   req.on('data', function(body) {
-    t.equals(body, 'foobar', 'Body should have been pushed from mock req.');
+    var strbody = body.toString('ascii');
+    t.equals(strbody, 'foobar', 'Body should have been pushed from mock req.');
     t.end();
   });
 

--- a/tests/res.js
+++ b/tests/res.js
@@ -1,0 +1,38 @@
+var test = require('tape');
+var MockRequest = require('../index.js').Request;
+var MockResponse = require('../index.js').Response;
+
+var domain = require('domain');
+
+test('error in response finish handler', function(t) {
+
+  var errmessage = 'error in async'
+
+  var dom = domain.create();
+  dom.on('error',function(err){
+    t.equal(err.message,errmessage,'the correct error message should be recieved');
+    t.end();
+  })
+
+  var res = new MockResponse();  
+
+  res.on('finish', function() {
+    var body = res.buffer.join('');
+    t.equal(res.statusCode, 200, 'Should return 200');
+    t.ok(body, 'Should return content');
+
+    throw new Error(errmessage)
+
+    t.notOk(true,'this should never be reached');
+  });
+
+  dom.run(function(){
+    try{
+      res.statusCode = 200;
+      res.end('done!');  
+    }
+    catch(e){
+      t.notOk(e,'the exception should not reach here');
+    }
+  });
+});


### PR DESCRIPTION
Since the same hammock response is used on both the "server" and the client side, exception handling in the server can cause the finish event on the response to be called multiple times. This can cause unit tests to fail with very unexpected results. This request wraps the client side events in the res.end method in a set immediate, to kinda simulate the response traveling over a network (I realize it's not a great simulation.) This prevents errors on the client side from invoking behavior on the server side.

As well I updated some of the tests to function better, and added tests for the specific case this covers.
