### PR TITLE
Support request style options.json

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -41,6 +41,12 @@ var MockRequest = function(options) {
   });
 
   this.setHeader('cookie', cookieBuffer.join(';'));
+  
+  if ('json' in options && typeof options.json !== 'boolean') {
+    process.nextTick(function () {
+      this.end(JSON.stringify(options.json));
+    });
+  }
 };
 
 util.inherits(MockRequest, EventEmitter);


### PR DESCRIPTION
This will make writing tests easier and get close to the `request` interface

``` js
MockRequest({
  method: 'POST',
  url: '/foo',
  json: { 'status': 42 }
})
```

instead of 

``` js
var req = MockRequest({
  method: 'POST',
  url: '/foo'
})

...

req.end(JSON.stringify({ status: '42' }))
```
