### PR TITLE
use PassThrough stream

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -2,7 +2,7 @@ var Cookies = require('cookies');
 var url = require('url');
 var http = require('http');
 var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+var PassThrough = require('readable-stream').PassThrough;
 var _ = require('lodash');
 
 
@@ -14,7 +14,7 @@ var MockRequest = function(options) {
     return new MockRequest(options);
   }
 
-  EventEmitter.call(this, options);
+  PassThrough.call(this, options);
 
   this.body = '';
   this.httpVersion = '1.1';
@@ -45,7 +45,7 @@ var MockRequest = function(options) {
   }
 };
 
-util.inherits(MockRequest, EventEmitter);
+util.inherits(MockRequest, PassThrough);
 
 
 MockRequest.prototype.setHeader = function(name, value, clobber) {
@@ -66,22 +66,6 @@ MockRequest.prototype.getHeader = function(name) {
   } else {
     return this.headers[name];
   }
-};
-
-MockRequest.prototype.pause = function() {};
-
-MockRequest.prototype.resume = function() {};
-
-MockRequest.prototype.write = function(str) {
-  this.body += str;
-};
-
-MockRequest.prototype.end = function(str) {
-  if (str) {
-    this.write(str);
-  }
-  this.emit('data', new Buffer(this.body));
-  this.emit('end');
 };
 
 module.exports = MockRequest;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   ],
   "dependencies": {
     "cookies": "~0.3.6",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "readable-stream": "~1.0.33"
   },
   "devDependencies": {
     "tape": "^3.0.3"

--- a/tests/post.js
+++ b/tests/post.js
@@ -26,10 +26,14 @@ test('Create  post request', function(t) {
   t.equal(foo, 'bar', 'Cookie (foo) should return the original value.');
   t.equal(bar, 'baz', 'Cookie (bar) should return the original value.');
 
+  var _body = ''
   req.on('data', function(body) {
-    t.equals(body.toString(), 'foobar', 'Body should have been pushed from mock req.');
+    _body += body
+  })
+  req.once('end', function () {
+    t.equals(_body.toString(), 'foobar', 'Body should have been pushed from mock req.');
     t.end();
-  });
+  })
 
   req.write('foo');
   req.end('bar');


### PR DESCRIPTION
This allows you to do `req.end('foo'); server(req, res);`

i.e. the Request is a now a proper buffering stream that
    will store the body instead of emitting it straight away.

This means you dont have to pass the `req` to the handler
    function before you end it.

cc @tommymessbauer