### PR TITLE
Update lodash to 3.x.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "cookies": "~0.3.6",
-    "lodash": "~2.4.1",
+    "lodash": "^3.0.0",
     "readable-stream": "~1.0.33"
   },
   "devDependencies": {


### PR DESCRIPTION
All tests pass and there are no breaking changes to the functions you are using in this lib. Also, they strictly follow semver, so `^` can be used safely with lodash versioning.