### PR TITLE
optimize building the response body

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -1,6 +1,7 @@
 var events = require('events');
 var util = require('util');
 var http = require('http');
+var Buffer = require('buffer').Buffer;
 
 /**
  * Mock response object for receiving content without a server.
@@ -76,20 +77,44 @@ MockResponse.prototype.getHeader = function (name) {
   }
 };
 MockResponse.prototype.end = function (str) {
-  this.buffer.push(str);
+  if (str) {
+    this.buffer.push(str);
+  }
+  
+  var body = this._buildBody();
+
   this.emit('close');
   this.emit('finish');
   this.emit('end', null, { // deprecate me
     statusCode: this.statusCode,
-    body: this.buffer.join(''),
+    body: body,
     headers: this._headers
   });
   this.emit('response', null, {
     statusCode: this.statusCode,
-    body: this.buffer.join(''),
+    body: body,
     headers: this._headers
   });
   this.finished = true
+};
+
+MockResponse.prototype._buildBody = function _buildBody() {
+  if (this.buffer.length === 1) {
+    return this.buffer[0];
+  }
+
+  var isBuffers = true;
+  for (var i = 0; i < this.buffer.length; i++) {
+    if (!Buffer.isBuffer(this.buffer[i])) {
+      isBuffers = false;
+    }
+  }
+
+  if (!isBuffers) {
+    return this.buffer.join('');
+  }
+
+  return Buffer.concat(this.buffer);
 };
 
 module.exports = MockResponse;

--- a/tests/req.js
+++ b/tests/req.js
@@ -37,3 +37,57 @@ test('can create with cookie header', function (t) {
 
   t.end();
 });
+
+test('can write to response', function t(assert) {
+  var res = new MockResponse(onResponse);
+
+  res.write('foo');
+  res.write('bar');
+  res.end();
+
+  function onResponse(err, resp) {
+    assert.equal(resp.body, 'foobar');
+    assert.end();
+  }
+});
+
+test('can write buffers to response', function t(assert) {
+  var res = new MockResponse(onResponse);
+
+  res.write('foo');
+  res.write(new Buffer('bar'));
+  res.end();
+
+  function onResponse(err, resp) {
+    assert.equal(resp.body, 'foobar');
+    assert.end();
+  }
+});
+
+test('can write buffer to end()', function t(assert) {
+  var res = new MockResponse(onResponse);
+
+  res.end(new Buffer('foobar'));
+
+  function onResponse(err, resp) {
+    assert.equal(
+      resp.body.toString('hex'), new Buffer('foobar').toString('hex')
+    );
+    assert.end();
+  }
+})
+
+test('can write only buffers to response', function t(assert) {
+  var res = new MockResponse(onResponse);
+
+  res.write(new Buffer('foo'));
+  res.write(new Buffer('bar'));
+  res.end();
+
+  function onResponse(err, resp) {
+    assert.equal(
+      resp.body.toString('hex'), new Buffer('foobar').toString('hex')
+    );
+    assert.end();
+  }
+});


### PR DESCRIPTION
This changes contains a few optimizations:
 
 - If there is just one part in the `buffer` array, return it
 - Only join() the `buffer` array once, instead of twice.
 - If the `buffer` array contains Buffers, use `Buffer.concat`

r: @tommymessbauer