### PR TITLE
cleanup listeners on end

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -77,6 +77,10 @@ MockResponse.prototype.getHeader = function (name) {
   }
 };
 MockResponse.prototype.end = function (str) {
+  if (this.finished) {
+    return;
+  }
+
   if (str) {
     this.buffer.push(str);
   }
@@ -96,6 +100,9 @@ MockResponse.prototype.end = function (str) {
     headers: this._headers
   });
   this.finished = true
+
+  // Cleanup any listeners that are 'hanging' around.
+  this.removeAllListeners();
 };
 
 MockResponse.prototype._buildBody = function _buildBody() {


### PR DESCRIPTION
We've observed that `resp` reference can be
quite long lived. We want to cleanup all the listeners
and closures stored on the `resp`, this should free
up some references to buffers which reduces the
retained size of an individual response.

r: @toannguyenle @tommymessbauer