### PR TITLE
Handle Empty Responses

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -106,6 +106,9 @@ MockResponse.prototype.end = function (str) {
 };
 
 MockResponse.prototype._buildBody = function _buildBody() {
+  if (this.buffer.length === 0) {
+    return '';
+  }
   if (this.buffer.length === 1) {
     return this.buffer[0];
   }

--- a/tests/req.js
+++ b/tests/req.js
@@ -2,6 +2,7 @@ var test = require('tape');
 var MockRequest = require('../index.js').Request;
 var MockResponse = require('../index.js').Response;
 var Cookies = require('cookies');
+var PassThrough = require('stream').PassThrough;
 
 test('Create request with cookie', function(t) {
   var req = new MockRequest({
@@ -91,3 +92,36 @@ test('can write only buffers to response', function t(assert) {
     assert.end();
   }
 });
+
+test('can write only buffers to response with pipe', function t(assert) {
+  var res = new MockResponse(onResponse);
+
+  var stream = new PassThrough();
+  stream.write(new Buffer('foo'));
+  stream.write(new Buffer('bar'));
+  stream.pipe(res);
+  stream.end();
+
+  function onResponse(err, resp) {
+    assert.equal(
+      resp.body.toString('hex'), new Buffer('foobar').toString('hex')
+    );
+    assert.end();
+  }
+});
+
+test('can handle empty responses', function t(assert) {
+  var res = new MockResponse(onResponse);
+
+  var stream = new PassThrough();
+  stream.pipe(res);
+  stream.end();
+
+  function onResponse(err, resp) {
+    assert.deepEqual(resp.body, '');
+    assert.end();
+  }
+});
+
+
+


### PR DESCRIPTION
There is a problem where sending empty responses to Hammock will cause an empty Buffer to be returned. Libraries that rely on JSON parsing bodys that exist will fail.

```
> Buffer.concat([])
<Buffer >
> JSON.parse(Buffer.concat([]))
SyntaxError: Unexpected end of input
    at Object.parse (native)
    at repl:1:7
    at REPLServer.self.eval (repl.js:110:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
    at ReadStream.emit (events.js:98:17)
```