### PR TITLE
read headers using getHeaders instead of using _headers

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -55,7 +55,11 @@ util.inherits(MockRequest, PassThrough);
 MockRequest.prototype.setHeader = function (name, value, clobber) {
   if (http.ClientRequest) {
     var ret = http.ClientRequest.prototype.setHeader.call(this, name, value, clobber);
-    this.headers = this._headers;
+    if (http.ClientRequest.prototype.getHeaders) {
+      this.headers = http.ClientRequest.prototype.getHeaders.call(this);
+    } else {
+      this.headers = this._headers;
+    }
     return ret;
   } else if (clobber || !this.headers.hasOwnProperty(name)) {
     this.headers[name.toLowerCase()] = value;

--- a/lib/response.js
+++ b/lib/response.js
@@ -61,7 +61,11 @@ MockResponse.prototype.writeHead = function (statusCode, headers) {
 MockResponse.prototype.setHeader = function (name, value, clobber) {
   if (http.ServerResponse) {
     var ret = http.ServerResponse.prototype.setHeader.call(this, name, value, clobber);
-    this.headers = this._headers;
+    if (http.ServerResponse.prototype.getHeaders) {
+      this.headers = http.ServerResponse.prototype.getHeaders.call(this);
+    } else {
+      this.headers = this._headers;
+    }
     return ret;
   } else if (clobber || !this.headers.hasOwnProperty(name)) {
     this.headers[name] = value;


### PR DESCRIPTION
In node8, _headers is deprecated, so the .headers field should be populated using the supplied getHeaders calls instead.