### PR TITLE
use readable-stream writable to correct res pipe

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
     Request: require('./lib/request'),
     Response: require('./lib/response')

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Cookies = require('cookies');
 var url = require('url');
 var http = require('http');

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,7 +1,10 @@
+'use strict';
+
 var events = require('events');
 var util = require('util');
 var http = require('http');
 var Buffer = require('buffer').Buffer;
+var Writable = require('readable-stream').Writable;
 
 // Some versions of node populate _headers while others
 // populate a symbol key (node10+)
@@ -15,9 +18,11 @@ var MockResponse = function (callback) {
     return new MockResponse(callback);
   }
 
-  events.EventEmitter.call(this);
+  Writable.call(this, {
+    decodeStrings: false
+  });
 
-  this.buffer = [];
+  this._buffer = [];
   this.statusCode = 200;
   this[outHeadersKey] = null;
   this._headers = {};
@@ -39,10 +44,11 @@ var MockResponse = function (callback) {
   this._removedHeader = {};
 };
 
-util.inherits(MockResponse, events.EventEmitter);
+util.inherits(MockResponse, Writable);
 
-MockResponse.prototype.write = function (str) {
-  this.buffer.push(str);
+MockResponse.prototype._write = function (chunk, enc, cb) {
+  this._buffer.push(chunk);
+  cb(null);
 };
 MockResponse.prototype.writeHead = function (statusCode, headers) {
   var that = this;
@@ -80,7 +86,7 @@ MockResponse.prototype.end = function (str) {
   }
 
   if (str) {
-    this.buffer.push(str);
+    this._buffer.push(str);
   }
   
   var body = this._buildBody();
@@ -105,31 +111,28 @@ MockResponse.prototype.end = function (str) {
     headers: headers
   });
   this.finished = true
-
-  // Cleanup any listeners that are 'hanging' around.
-  this.removeAllListeners();
 };
 
 MockResponse.prototype._buildBody = function _buildBody() {
-  if (this.buffer.length === 0) {
+  if (this._buffer.length === 0) {
     return '';
   }
-  if (this.buffer.length === 1) {
-    return this.buffer[0];
+  if (this._buffer.length === 1) {
+    return this._buffer[0];
   }
 
   var isBuffers = true;
-  for (var i = 0; i < this.buffer.length; i++) {
-    if (!Buffer.isBuffer(this.buffer[i])) {
+  for (var i = 0; i < this._buffer.length; i++) {
+    if (!Buffer.isBuffer(this._buffer[i])) {
       isBuffers = false;
     }
   }
 
   if (!isBuffers) {
-    return this.buffer.join('');
+    return this._buffer.join('');
   }
 
-  return Buffer.concat(this.buffer);
+  return Buffer.concat(this._buffer);
 };
 
 function readOutHeadersKey() {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "readable-stream": "^2.3.3"
   },
   "devDependencies": {
+    "nock": "^8.2.2",
+    "request": "^2.88.0",
     "tape": "^4.8.0"
   },
   "author": "Tommy Messbauer",

--- a/request.js
+++ b/request.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = require("./lib/request");

--- a/response.js
+++ b/response.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = require("./lib/response");

--- a/tests/pipe.js
+++ b/tests/pipe.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var test = require('tape');
+
+var Buffer = require('buffer').Buffer;
+var nock = require('nock');
+var PassThrough = require('readable-stream').PassThrough;
+var request = require('request');
+
+var MockRequest = require('../index.js').Request;
+var MockResponse = require('../index.js').Response;
+
+test('nock should return response', function t(assert) {
+
+    nock('http://localhost:5555')
+        .post('/derp')
+        .reply(200, '{a');
+
+    request.post('http://localhost:5555/derp', onResponse);
+
+    function onResponse(err, res, body) {
+        assert.ifError(err, 'Unexpected error in resonse');
+        assert.strictEqual('{a', String(body));
+        assert.end();
+    }
+});
+
+test('request should pipe data', function t(assert) {
+    nock('http://localhost:5555')
+        .post('/derp', '{a')
+        .reply(200, '{b');
+
+    var chunks = [];
+    var p = new PassThrough();
+    p.on('data', function accumulate(d) {
+        chunks.push(d);
+    });
+    p.on('end', function assertTest() {
+        var data = Buffer.concat(chunks);
+        assert.strictEqual(String(data), '{b');
+        assert.end();
+    });
+
+    request.post({
+        url: 'http://localhost:5555/derp',
+        body: '{a'
+    }).pipe(p);
+});
+
+test('request should pipe through hammock req', function t(assert) {
+    nock('http://localhost:5555')
+        .post('/derp', '{a')
+        .reply(200, '{b');
+
+    var req = MockRequest({
+        url: 'http://localhost:5555/derp',
+        method: 'POST'
+    });
+
+    var chunks = [];
+    var p = new PassThrough();
+    p.on('data', function accumulate(d) {
+        chunks.push(d);
+    });
+    p.on('end', function assertTest() {
+        var data = Buffer.concat(chunks);
+        assert.strictEqual(String(data), '{b');
+        assert.end();
+    });
+
+    req.pipe(request.post('http://localhost:5555/derp'))
+        .pipe(p);
+
+    req.write('{a');
+    req.end();
+});
+
+test('response should pipe through hammock res', function t(assert) {
+    nock('http://localhost:5555', {
+        reqHeaders: {
+            'x-test-request': 'RequestValue'
+        }
+    }).post('/derp', '{a')
+    .reply(200, '{b', {'x-test-response': 'ResponseValue'});
+
+    var req = MockRequest({
+        url: 'http://localhost:5555/derp',
+        method: 'POST',
+        headers: {
+            'x-test-request': 'RequestValue'
+        }
+    });
+    var res = MockResponse(function onRes(err, response) {
+        assert.ifError(err);
+        assert.strictEqual(String(response.body), '{b');
+        assert.deepEqual(response.headers, {
+            'x-test-response': 'ResponseValue'
+        });
+        assert.end();
+    });
+
+    req.pipe(request.post('http://localhost:5555/derp'))
+        .pipe(res);
+
+    req.write('{a');
+    req.end();
+});

--- a/tests/post.js
+++ b/tests/post.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var test = require('tape');
 var MockRequest = require('../index.js').Request;
 var MockResponse = require('../index.js').Response;

--- a/tests/req.js
+++ b/tests/req.js
@@ -1,8 +1,10 @@
+'use strict';
+
 var test = require('tape');
 var MockRequest = require('../index.js').Request;
 var MockResponse = require('../index.js').Response;
 var Cookies = require('cookies');
-var PassThrough = require('stream').PassThrough;
+var PassThrough = require('readable-stream').PassThrough;
 
 test('Create request with cookie', function(t) {
   var req = new MockRequest({


### PR DESCRIPTION
I'm seeing interesting behavior with pipe into responses across various versions of node. In some versions I see empty data, and it seems really difficult to solve with an event-emitter based implementation only. The most compatible way to solve this problem is to inherit from readable-stream v2 writable, which I have done here.

I have also added an example to prove that proxying requests with request actually works, as this was my original breaking use case.

I have tested with all versions since 0.10. I would highly recommend releasing this as a patch version i.e. v3.0.1

Also as an interesting observation, by inheriting from writable I think this technically works with node 0.8, but the modules included for tests do not seem to work with node 0.8.